### PR TITLE
Fix punctuality.rb date range

### DIFF
--- a/punctuality (frontend)/punctuality.rb
+++ b/punctuality (frontend)/punctuality.rb
@@ -77,7 +77,7 @@ def api_data_from_file(filename, from, to)
   to = Date.parse(to) unless to.is_a?(Date)
 
   data = CSV.parse(File.read("#{filename}.csv"), headers: true)
-  range = from..(to + 1)
+  range = from..to
 
   data.find_all {|row|
     date = Date.strptime(row['date'], "%d/%m/%y") rescue Date.parse(row['date'])


### PR DESCRIPTION
Range was inclusive of `(to + 1)`. This meant that a call such as `/rosters/2013-01-01/2013-10-19` would include data for `2013-10-20`