### PR TITLE
Add 'name' to the /auth/signup body json

### DIFF
--- a/adnat (react)/backend/README.md
+++ b/adnat (react)/backend/README.md
@@ -33,6 +33,7 @@ If you receive a non-200 response code. There should be a message in the `error`
 ```javascript
 // body
 {
+  "name": "Barney Rubble",
   "email": "barney@gmail.com",
   "password": "mypassword",
   "passwordConfirmation": "mypassword"


### PR DESCRIPTION
The example json object for /auth/signup does not include a 'name' property.  This is required for SQLite db insert.  With out this property the error '(node:7740) UnhandledPromiseRejectionWarning: Error: SQLITE_CONSTRAINT: NOT NULL constraint failed: users.name' is returned on the server.