### PR TITLE
Small fixes for Adnet (React) Challenge Endpoint README

### DIFF
--- a/adnat (react)/backend/README.md
+++ b/adnat (react)/backend/README.md
@@ -244,12 +244,20 @@ If you receive a non-200 response code. There should be a message in the `error`
 
 ```javascript
 // response
-{
-  "id": 1,
-  "organisationId": 1,
-  "name": "Dave Allie",
-  "email": "dave@tanda.co"
-}
+[
+  {
+    "id": 1,
+    "organisationId": 1,
+    "name": "Dave Allie",
+    "email": "dave@tanda.co"
+  },
+  {
+    "id": 2,
+    "organisationId": 1,
+    "name": "Dan Gilchrist",
+    "email": "dan@tanda.co"
+  }
+];
 ```
 
 ### Get User Information

--- a/adnat (react)/backend/README.md
+++ b/adnat (react)/backend/README.md
@@ -116,7 +116,7 @@ If you receive a non-200 response code. There should be a message in the `error`
 ```javascript
 // body
 {
-	"organisationId": 1
+  "organisationId": 1
 }
 
 // response
@@ -157,7 +157,7 @@ If you receive a non-200 response code. There should be a message in the `error`
 **`GET`**`/shifts`
 
 ```javascript
-// repsonse
+// response
 [
   {
     id: 1,

--- a/adnat (react)/backend/README.md
+++ b/adnat (react)/backend/README.md
@@ -66,6 +66,11 @@ If you receive a non-200 response code. There should be a message in the `error`
 
 **`DELETE`**`/auth/logout`
 
+```javascript
+// response
+200
+````
+
 ---
 
 ## Organisations
@@ -134,6 +139,9 @@ If you receive a non-200 response code. There should be a message in the `error`
   "name": "New Organisation",
   "hourlyRate": 34.5 // optional
 }
+
+// response
+200
 ```
 
 ### Leave Organisation
@@ -221,6 +229,11 @@ If you receive a non-200 response code. There should be a message in the `error`
 
 **`DELETE`**`/shifts/:id`
 
+```javascript
+// response
+200
+```
+
 ---
 
 ## Users
@@ -284,4 +297,7 @@ If you receive a non-200 response code. There should be a message in the `error`
 	"newPassword": "gfdkljdfgdfgjkldfgkljfgljk",
 	"newPasswordConfirmation": "gfdkljdfgdfgjkldfgkljfgljk"
 }
+
+// response
+200
 ```

--- a/adnat (react)/backend/README.md
+++ b/adnat (react)/backend/README.md
@@ -97,8 +97,8 @@ If you receive a non-200 response code. There should be a message in the `error`
 ```javascript
 // body
 {
-	"name": "My Organisation",
-	"hourlyRate": 100.12 // optional
+  "name": "My Organisation",
+  "hourlyRate": 100.12
 }
 
 // response
@@ -164,7 +164,7 @@ If you receive a non-200 response code. There should be a message in the `error`
     userId: 1,
     start: "2018-01-01 10:15",
     finish: "2018-01-01 10:20",
-    breakLength: null
+    breakLength: 40
   },
   {
     id: 2,

--- a/adnat (react)/backend/README.md
+++ b/adnat (react)/backend/README.md
@@ -136,7 +136,7 @@ If you receive a non-200 response code. There should be a message in the `error`
 ```javascript
 // body
 {
-  "name": "New Organisation",
+  "name": "New Organisation", // optional
   "hourlyRate": 34.5 // optional
 }
 

--- a/adnat (react)/backend/README.md
+++ b/adnat (react)/backend/README.md
@@ -281,16 +281,16 @@ If you receive a non-200 response code. There should be a message in the `error`
 ```javascript
 // body
 {
-  "name": "Not Barney", // optional
-  "email": "notbarney@gmail.com" //optional
+  "name": "Not Dave Allie", // optional
+  "email": "notdave@tanda.co" // optional
 }
 
 // response
 {
   "id": 1,
   "organisationId": 1,
-  "name": "Not Barney",
-  "email": "notbarney@gmail.com"
+  "name": "Not Dave Allie",
+  "email": "notdave@tanda.co"
 }
 ```
 
@@ -301,9 +301,9 @@ If you receive a non-200 response code. There should be a message in the `error`
 ```javascript
 // body
 {
-	"oldPassword": "opensesame",
-	"newPassword": "gfdkljdfgdfgjkldfgkljfgljk",
-	"newPasswordConfirmation": "gfdkljdfgdfgjkldfgkljfgljk"
+  "oldPassword": "opensesame",
+  "newPassword": "opensesame123",
+  "newPasswordConfirmation": "opensesame123"
 }
 
 // response


### PR DESCRIPTION
Main points
- `hourly_rate` has a `NOT NULL` constraint and we had it as optional for the `POST /create_join` endpoint and an example with it set to `null`
- `name` is optional when updating an organisation
- `GET /users` now shows an array of user objects as the response (was single user object)
- Everything else are just changes to be more explicit/readable/whatever