### PR TITLE
Bump SQLite3 | node-pre-gyp http 403

### DIFF
--- a/adnat (react)/backend/index.js
+++ b/adnat (react)/backend/index.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const cors = require('cors')
 const bodyParser = require("body-parser");
 const authRouter = require("./router/auth");
 const organisationsRouter = require("./router/organisations");
@@ -6,6 +7,7 @@ const shiftsRouter = require("./router/shifts");
 const usersRouter = require("./router/users");
 const app = express();
 
+app.use(cors())
 app.use(bodyParser.json());
 app.use("/auth", authRouter);
 app.use("/organisations", organisationsRouter);

--- a/adnat (react)/backend/package.json
+++ b/adnat (react)/backend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "bcrypt": "^5.0.0",
     "body-parser": "^1.18.3",
+    "cors": "^2.8.5",
     "express": "^4.16.4",
     "sqlite3": "^5.0.0",
     "uuid": "^3.3.2"

--- a/adnat (react)/backend/yarn.lock
+++ b/adnat (react)/backend/yarn.lock
@@ -193,6 +193,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -792,7 +800,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0:
+object-assign@^4, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -1194,7 +1202,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
I'm not entirely across why we are getting errors here however the version of node-pre-gyp used in sqlite3 has changed: https://github.com/mapbox/node-sqlite3/pull/1441

sqlite3@5.0.0 seems to install and function correctly however more debugging needs to be conducted before merging this. 


### Version 4.1.0
```
node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@0.11.0
node-pre-gyp info using node@16.0.0 | darwin | x64
node-pre-gyp WARN Using request for node-pre-gyp https download
node-pre-gyp info check checked for "/Users/lachlanyoung/projects/tanda/work-samples/adnat (react)/backend/node_modules/sqlite3/lib/binding/node-v93-darwin-x64/node_sqlite3.node" (not found)
node-pre-gyp http GET https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v4.1.0/node-v93-darwin-x64.tar.gz
node-pre-gyp http 403 https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v4.1.0/node-v93-darwin-x64.tar.gz
node-pre-gyp WARN Tried to download(403): https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v4.1.0/node-v93-darwin-x64.tar.gz
node-pre-gyp WARN Pre-built binaries not found for sqlite3@4.1.0 and node@16.0.0 (node-v93 ABI, unknown) (falling back to source compile with node-gyp)
node-pre-gyp http 403 status code downloading tarball https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v4.1.0/node-v93-darwin-x64.tar.gz
```

### Version 5.0.0
<img width="1431" alt="CleanShot 2021-10-28 at 15 36 42@2x" src="https://user-images.githubusercontent.com/16897508/139193699-b0b0fbbe-516e-4bf8-88fe-12e99b9fdeb2.png">
